### PR TITLE
fix: error path resolve in windows

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -6,11 +6,11 @@ import fs from 'fs'
 import humps from 'humps'
 import { exec } from 'child_process'
 import ora from 'ora'
-import { URL } from 'node:url';
+import { URL, fileURLToPath } from 'node:url';
 import yargs from 'yargs'
 import { hideBin } from 'yargs/helpers'
 
-const __dirname = path.dirname(new URL(import.meta.url).pathname)
+const __dirname = path.dirname(fileURLToPath(new URL(import.meta.url)))
 
 const args = process.argv.slice(2)
 


### PR DESCRIPTION
This PR addresses the issue of path handling for cross-platform compatibility and includes a version bump for the create-answer-plugin package.

The use of `const __dirname = path.dirname(new URL(import.meta.url).pathname)` will cause the wrong path in the following path resolve in Windows system,

For testing

```js
import { URL } from 'node:url';
import path from 'path'

const __dirname = path.dirname(new URL(import.meta.url).pathname)
const templatePath = path.resolve(__dirname, '../template/plugin.go')

console.log(templatePath)
```

and the result in node(v20.4.0) on windows will print `D:\D:\create-answer-plugin\template\plugin.go` which will cause the following error

```
Error: ENOENT: no such file or directory, scandir 'D:\D:\create-answer-plugin\template\i18n'
    at Object.readdirSync (node:fs:1534:3)
    at createI18n (file:///D:/create-answer-plugin/bin/index.js:105:6)
    at file:///D:/create-answer-plugin/bin/index.js:135:3
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5) {
  errno: -4058,
  syscall: 'scandir',
  code: 'ENOENT',
  path: 'D:\\D:\\create-answer-plugin\\template\\i18n'
}
```