### PR TITLE
fix: update repository links from incubator to main Answer project

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Create Answer Plugin
 
-This tool is used to create a new plugin for the [Answer](https://github.com/apache/incubator-answer) project.
+This tool is used to create a new plugin for the [Answer](https://github.com/apache/answer) project.
 
 ## Usage
 

--- a/bin/index.js
+++ b/bin/index.js
@@ -126,7 +126,7 @@ const createReadme = async ({ pluginName, targetPath }) => {
 }
 const installGoMod = async ({ packageName }) => {
   process.chdir(path.resolve(process.cwd(), packageName))
-  await exec(`go mod init github.com/apache/incubator-answer-plugins/${packageName} && go mod tidy`)
+  await exec(`go mod init github.com/apache/answer-plugins/${packageName} && go mod tidy`)
 }
 
 const installNpm = async () => {

--- a/template/plugin.go
+++ b/template/plugin.go
@@ -1,9 +1,9 @@
 package answer
 import (
   "embed"
-  "github.com/apache/incubator-answer/plugin"
+  "github.com/apache/answer/plugin"
 
-  "github.com/apache/incubator-answer-plugins/util"
+  "github.com/apache/answer-plugins/util"
 )
 
 //go:embed  info.yaml


### PR DESCRIPTION
This pull request includes updates to the `README.md` and `template/plugin.go` files to reflect the correct project repository URLs after the project moved from the Apache incubator to the main Apache repository.

Changes to repository URLs:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L3-R3): Updated the project URL from `https://github.com/apache/incubator-answer` to `https://github.com/apache/answer`.
* [`template/plugin.go`](diffhunk://#diff-1280727b7954de3bf1f1d3546d4e6167f496d8a0d3c12b6fc34a2465591324a2L4-R6): Updated the import paths to use `github.com/apache/answer/plugin` and `github.com/apache/answer-plugins/util` instead of the old `incubator` paths.